### PR TITLE
Fixed migration length issue by changing app service provider

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -3,6 +3,7 @@
 namespace App\Providers;
 
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Support\Facades\Schema;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -24,5 +25,6 @@ class AppServiceProvider extends ServiceProvider
     public function boot()
     {
         //
+        Schema::defaultStringLength(191);
     }
 }


### PR DESCRIPTION
Length overflow issue made by upgrading laravel by implementing of emoj storage in db. 
Fixed by changing maxlength of string in appServiceProvider.php. 

